### PR TITLE
feat: 对于不支持 `max_tokens` 的模型，自适应使用 `max_completion_tokens`

### DIFF
--- a/android/app/src/main/kotlin/io/github/hyperisland/xposed/template/AINotificationIslandNotification.kt
+++ b/android/app/src/main/kotlin/io/github/hyperisland/xposed/template/AINotificationIslandNotification.kt
@@ -32,7 +32,6 @@ import java.util.concurrent.Executors
 import java.util.concurrent.Future
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
-import java.util.concurrent.ConcurrentHashMap
 
 /**
  * AI 增强版通知超级岛。

--- a/android/app/src/main/kotlin/io/github/hyperisland/xposed/template/AINotificationIslandNotification.kt
+++ b/android/app/src/main/kotlin/io/github/hyperisland/xposed/template/AINotificationIslandNotification.kt
@@ -32,6 +32,7 @@ import java.util.concurrent.Executors
 import java.util.concurrent.Future
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * AI 增强版通知超级岛。
@@ -117,6 +118,10 @@ object AINotificationIslandNotification : IslandTemplate {
         triggerCharCount = ConfigManager.getInt("pref_ai_trigger_char_count", 10).coerceIn(0, 100),
     )
 
+    private val maxCompletionPrefixes = listOf("o1", "o3", "o4", "gpt-5")
+    @Volatile
+    private var maxTokenParamName: String = "max_tokens"
+
     // ── AI 调用（带超时） ──────────────────────────────────────────────────────
 
     private fun fetchAiText(config: AiConfig, data: NotifData): AiIslandText? {
@@ -136,7 +141,15 @@ object AINotificationIslandNotification : IslandTemplate {
     }
 
     private fun callAiApi(config: AiConfig, data: NotifData): AiIslandText? {
-        val response = postAiRequest(config, buildRequestBody(config, data))
+        val firstParam = tokenParamFor(config.model.ifEmpty { "gpt-4o-mini" })
+        var response = postAiRequest(config, buildRequestBody(config, data, firstParam))
+        // 400 且错误信息中包含 max_tokens 或 max_completion_tokens 时，切换参数名重试
+        if (response.first == HttpURLConnection.HTTP_BAD_REQUEST && isTokenParamError(response.second)) {
+            val alt = if (firstParam == "max_tokens") "max_completion_tokens" else "max_tokens"
+            maxTokenParamName = alt
+            // 重试时直接用 alt，绕过名单
+            response = postAiRequest(config, buildRequestBody(config, data, alt))
+        }
         val code = response.first
         val responseBody = response.second
         if (code != HttpURLConnection.HTTP_OK) {
@@ -168,7 +181,14 @@ object AINotificationIslandNotification : IslandTemplate {
         }
     }
 
-    private fun buildRequestBody(config: AiConfig, data: NotifData): String {
+    private fun tokenParamFor(model: String): String = if (maxCompletionPrefixes.any { model.startsWith(it) }) "max_completion_tokens" else maxTokenParamName
+
+    private fun isTokenParamError(body: String): Boolean {
+        val b = body.lowercase()
+        return b.contains("max_completion_tokens") || b.contains("max_tokens")
+    }
+
+    private fun buildRequestBody(config: AiConfig, data: NotifData, tokenParam: String): String {
         val defaultPrompt = "根据通知信息，提取关键信息，左右分别不超过6汉字12字符"
         val userPrompt = if (config.prompt.isNotEmpty()) config.prompt else defaultPrompt
 
@@ -204,7 +224,7 @@ $userPrompt
         val body = JSONObject()
             .put("model", model)
             .put("messages", messages)
-            .put("max_tokens", config.maxTokens)
+            .put(tokenParam, config.maxTokens)
             .put("temperature", config.temperature)
 
         try {

--- a/android/app/src/main/kotlin/io/github/hyperisland/xposed/template/AINotificationIslandNotification.kt
+++ b/android/app/src/main/kotlin/io/github/hyperisland/xposed/template/AINotificationIslandNotification.kt
@@ -118,8 +118,19 @@ object AINotificationIslandNotification : IslandTemplate {
     )
 
     private val maxCompletionPrefixes = listOf("o1", "o3", "o4", "gpt-5")
+    private val reservedRequestFields = setOf(
+        "max_tokens",
+        "max_completion_tokens",
+    )
+
+    private data class LearnedTokenParam(
+        val url: String,
+        val model: String,
+        val name: String,
+    )
+
     @Volatile
-    private var maxTokenParamName: String = "max_tokens"
+    private var learnedTokenParam: LearnedTokenParam? = null
 
     // ── AI 调用（带超时） ──────────────────────────────────────────────────────
 
@@ -140,14 +151,16 @@ object AINotificationIslandNotification : IslandTemplate {
     }
 
     private fun callAiApi(config: AiConfig, data: NotifData): AiIslandText? {
-        val firstParam = tokenParamFor(config.model.ifEmpty { "gpt-4o-mini" })
+        val model = config.model.ifEmpty { "gpt-4o-mini" }
+        val firstParam = tokenParamFor(config.url, model)
         var response = postAiRequest(config, buildRequestBody(config, data, firstParam))
-        // 400 且错误信息中包含 max_tokens 或 max_completion_tokens 时，切换参数名重试
-        if (response.first == HttpURLConnection.HTTP_BAD_REQUEST && isTokenParamError(response.second)) {
+
+        if (isUnsupportedTokenParamError(response.first, response.second, firstParam)) {
             val alt = if (firstParam == "max_tokens") "max_completion_tokens" else "max_tokens"
-            maxTokenParamName = alt
-            // 重试时直接用 alt，绕过名单
             response = postAiRequest(config, buildRequestBody(config, data, alt))
+            if (response.first == HttpURLConnection.HTTP_OK) {
+                learnedTokenParam = LearnedTokenParam(config.url.trim(), normalizeModel(model), alt)
+            }
         }
         val code = response.first
         val responseBody = response.second
@@ -180,12 +193,45 @@ object AINotificationIslandNotification : IslandTemplate {
         }
     }
 
-    private fun tokenParamFor(model: String): String = if (maxCompletionPrefixes.any { model.startsWith(it) }) "max_completion_tokens" else maxTokenParamName
-
-    private fun isTokenParamError(body: String): Boolean {
-        val b = body.lowercase()
-        return b.contains("max_completion_tokens") || b.contains("max_tokens")
+    private fun tokenParamFor(url: String, model: String): String {
+        val normalizedModel = normalizeModel(model)
+        val learned = learnedTokenParam
+        if (learned?.url == url.trim() && learned.model == normalizedModel) return learned.name
+        return if (maxCompletionPrefixes.any { normalizedModel.startsWith(it) }) {
+            "max_completion_tokens"
+        } else {
+            "max_tokens"
+        }
     }
+
+    private fun normalizeModel(model: String): String = model.trim().lowercase().substringAfterLast('/')
+
+    private fun isUnsupportedTokenParamError(code: Int, body: String, sentParam: String): Boolean {
+        if (code != HttpURLConnection.HTTP_BAD_REQUEST) return false
+
+        val error = try { JSONObject(body).optJSONObject("error") } catch (_: Exception) { null }
+        val errorParam = error?.optString("param")?.lowercase().orEmpty()
+        val errorCode = error?.optString("code")?.lowercase().orEmpty()
+        val message = error?.optString("message", body)?.lowercase() ?: body.lowercase()
+        if (errorParam == sentParam && (
+                errorCode.contains("unsupported") ||
+                    errorCode.contains("unknown") ||
+                    hasUnsupportedWording(message)
+                )
+        ) {
+            return true
+        }
+
+        return message.contains(sentParam) && hasUnsupportedWording(message)
+    }
+
+    private fun hasUnsupportedWording(message: String): Boolean =
+        message.contains("unsupported") ||
+            message.contains("not supported") ||
+            message.contains("unknown parameter") ||
+            message.contains("unrecognized") ||
+            message.contains("not allowed") ||
+            message.contains("use max_")
 
     private fun buildRequestBody(config: AiConfig, data: NotifData, tokenParam: String): String {
         val defaultPrompt = "根据通知信息，提取关键信息，左右分别不超过6汉字12字符"
@@ -228,7 +274,11 @@ $userPrompt
 
         try {
             val customFields = JSONObject(config.customFields)
-            customFields.keys().forEach { key -> body.put(key, customFields.get(key)) }
+            customFields.keys().forEach { key ->
+                if (key !in reservedRequestFields) {
+                    body.put(key, customFields.get(key))
+                }
+            }
         } catch (e: Exception) {
             logWarn("$TAG: ignoring invalid custom fields: ${e.message}")
         }

--- a/lib/pages/ai_config_page.dart
+++ b/lib/pages/ai_config_page.dart
@@ -209,6 +209,34 @@ class _AiConfigPageState extends State<AiConfigPage> {
 
   String _effectiveModel(String model) => model.isEmpty ? 'gpt-4o-mini' : model;
 
+  String _tokenParamName(String model) {
+    const prefixes = ['o1', 'o3', 'o4', 'gpt-5'];
+    return prefixes.any(model.startsWith) ? 'max_completion_tokens' : 'max_tokens';
+  }
+
+  bool _isTokenParamError(String body) {
+    final b = body.toLowerCase();
+    return b.contains('max_tokens') || b.contains('max_completion_tokens');
+  }
+
+  /// 封装了 API POST；400 且错误信息中包含 max_tokens 或 max_completion_tokens 时切换参数名重试
+  Future<http.Response> _postWithTokenFallback(
+    String url,
+    String key,
+    String model,
+    Future<http.Response> Function(String tokenParam) send,
+  ) async {
+    final firstParam = _tokenParamName(_effectiveModel(model));
+    var response = await send(firstParam);
+    if (response.statusCode == 400 && _isTokenParamError(response.body)) {
+      final alt = firstParam == 'max_tokens'
+          ? 'max_completion_tokens'
+          : 'max_tokens';
+      response = await send(alt);
+    }
+    return response;
+  }
+
   /// Derive the `/models` endpoint from the chat completions URL.
   ///
   /// Handles common shapes:
@@ -268,8 +296,10 @@ class _AiConfigPageState extends State<AiConfigPage> {
     required String model,
     required String promptText,
     required String userContent,
+    String? tokenParamName,
   }) {
     final effectiveModel = _effectiveModel(model);
+    final key = tokenParamName ?? _tokenParamName(effectiveModel);
     return <String, dynamic>{
       'model': effectiveModel,
       'messages': [
@@ -279,7 +309,7 @@ class _AiConfigPageState extends State<AiConfigPage> {
           {'role': 'user', 'content': promptText},
         {'role': 'user', 'content': userContent},
       ],
-      'max_tokens': _ctrl.aiMaxTokens,
+      key: _ctrl.aiMaxTokens,
       'temperature': _ctrl.aiTemperature,
       ..._customRequestFields(),
     };
@@ -350,24 +380,28 @@ class _AiConfigPageState extends State<AiConfigPage> {
       final sampleUserContent = AppLocalizations.of(
         context,
       )!.aiTestSampleUserContent;
-      final requestBody = jsonEncode(
-        _buildRequestPayload(
-          model: model,
-          promptText: '',
-          userContent: sampleUserContent,
-        ),
-      );
-      final response = await http
-          .post(
-            Uri.parse(url),
-            headers: {
-              'Content-Type': 'application/json',
-              'Accept': 'application/json',
-              if (key.isNotEmpty) 'Authorization': 'Bearer $key',
-            },
-            body: requestBody,
-          )
-          .timeout(Duration(seconds: _ctrl.aiTimeout));
+      final response = await _postWithTokenFallback(url, key, model,
+          (tokenParam) {
+        final requestBody = jsonEncode(
+          _buildRequestPayload(
+            model: model,
+            promptText: '',
+            userContent: sampleUserContent,
+            tokenParamName: tokenParam,
+          ),
+        );
+        return http
+            .post(
+              Uri.parse(url),
+              headers: {
+                'Content-Type': 'application/json',
+                'Accept': 'application/json',
+                if (key.isNotEmpty) 'Authorization': 'Bearer $key',
+              },
+              body: requestBody,
+            )
+            .timeout(Duration(seconds: _ctrl.aiTimeout));
+      });
 
       if (response.statusCode == 200) {
         final json = jsonDecode(response.body) as Map<String, dynamic>;
@@ -432,24 +466,29 @@ class _AiConfigPageState extends State<AiConfigPage> {
             },
             {'role': 'user', 'content': userContent},
           ];
-    final requestBody = jsonEncode(<String, dynamic>{
-      'model': _effectiveModel(model),
-      'messages': messages,
-      'max_tokens': _ctrl.aiMaxTokens,
-      'temperature': _ctrl.aiTemperature,
-      ..._customRequestFields(),
+    final effectiveModel = _effectiveModel(model);
+
+    final response = await _postWithTokenFallback(url, key, model,
+        (tokenParam) {
+      final requestBody = jsonEncode(<String, dynamic>{
+        'model': effectiveModel,
+        'messages': messages,
+        tokenParam: _ctrl.aiMaxTokens,
+        'temperature': _ctrl.aiTemperature,
+        ..._customRequestFields(),
+      });
+      return http
+          .post(
+            Uri.parse(url),
+            headers: {
+              'Content-Type': 'application/json',
+              'Accept': 'application/json',
+              if (key.isNotEmpty) 'Authorization': 'Bearer $key',
+            },
+            body: requestBody,
+          )
+          .timeout(Duration(seconds: _ctrl.aiTimeout));
     });
-    final response = await http
-        .post(
-          Uri.parse(url),
-          headers: {
-            'Content-Type': 'application/json',
-            'Accept': 'application/json',
-            if (key.isNotEmpty) 'Authorization': 'Bearer $key',
-          },
-          body: requestBody,
-        )
-        .timeout(Duration(seconds: _ctrl.aiTimeout));
 
     if (response.statusCode != 200) {
       throw Exception('HTTP ${response.statusCode}\n${response.body}');

--- a/lib/pages/ai_config_page.dart
+++ b/lib/pages/ai_config_page.dart
@@ -39,6 +39,7 @@ class _AiConfigPageState extends State<AiConfigPage> {
   late bool _aiEnabledValue;
   late bool _aiPromptInUserValue;
   bool _localizedDefaultsInitialized = false;
+  _LearnedTokenParam? _learnedTokenParam;
 
   void _onCtrlChanged() {
     if (!mounted) return;
@@ -192,7 +193,11 @@ class _AiConfigPageState extends State<AiConfigPage> {
   Map<String, dynamic> _customRequestFields() {
     try {
       final decoded = jsonDecode(_ctrl.aiCustomFields);
-      if (decoded is Map<String, dynamic>) return decoded;
+      if (decoded is Map<String, dynamic>) {
+        return Map<String, dynamic>.from(decoded)
+          ..remove('max_tokens')
+          ..remove('max_completion_tokens');
+      }
     } on FormatException {
       // Invalid persisted data is ignored so it cannot break AI requests.
     }
@@ -209,30 +214,81 @@ class _AiConfigPageState extends State<AiConfigPage> {
 
   String _effectiveModel(String model) => model.isEmpty ? 'gpt-4o-mini' : model;
 
-  String _tokenParamName(String model) {
+  String _normalizedModel(String model) =>
+      _effectiveModel(model).trim().toLowerCase().split('/').last;
+
+  String _tokenParamName(String url, String model) {
+    final normalizedModel = _normalizedModel(model);
+    final learned = _learnedTokenParam;
+    if (learned != null &&
+        learned.url == url.trim() &&
+        learned.model == normalizedModel) {
+      return learned.name;
+    }
     const prefixes = ['o1', 'o3', 'o4', 'gpt-5'];
-    return prefixes.any(model.startsWith) ? 'max_completion_tokens' : 'max_tokens';
+    return prefixes.any(normalizedModel.startsWith)
+        ? 'max_completion_tokens'
+        : 'max_tokens';
   }
 
-  bool _isTokenParamError(String body) {
-    final b = body.toLowerCase();
-    return b.contains('max_tokens') || b.contains('max_completion_tokens');
+  bool _hasUnsupportedWording(String message) {
+    return message.contains('unsupported') ||
+        message.contains('not supported') ||
+        message.contains('unknown parameter') ||
+        message.contains('unrecognized') ||
+        message.contains('not allowed') ||
+        message.contains('use max_');
   }
 
-  /// 封装了 API POST；400 且错误信息中包含 max_tokens 或 max_completion_tokens 时切换参数名重试
+  bool _isUnsupportedTokenParamError(http.Response response, String sentParam) {
+    if (response.statusCode != 400) return false;
+
+    Map<String, dynamic>? error;
+    try {
+      final decoded = jsonDecode(response.body);
+      if (decoded is Map<String, dynamic> &&
+          decoded['error'] is Map<String, dynamic>) {
+        error = decoded['error'] as Map<String, dynamic>;
+      }
+    } on FormatException {
+      // Non-standard providers may return a plain-text error body.
+    }
+
+    final errorParam = error?['param']?.toString().toLowerCase() ?? '';
+    final errorCode = error?['code']?.toString().toLowerCase() ?? '';
+    final message = (error?['message']?.toString() ?? response.body)
+        .toLowerCase();
+    if (errorParam == sentParam &&
+        (errorCode.contains('unsupported') ||
+            errorCode.contains('unknown') ||
+            _hasUnsupportedWording(message))) {
+      return true;
+    }
+    return message.contains(sentParam) && _hasUnsupportedWording(message);
+  }
+
+  /// Retry once with the alternate token-limit parameter when unsupported.
   Future<http.Response> _postWithTokenFallback(
     String url,
     String key,
     String model,
     Future<http.Response> Function(String tokenParam) send,
   ) async {
-    final firstParam = _tokenParamName(_effectiveModel(model));
+    final effectiveModel = _effectiveModel(model);
+    final firstParam = _tokenParamName(url, effectiveModel);
     var response = await send(firstParam);
-    if (response.statusCode == 400 && _isTokenParamError(response.body)) {
+    if (_isUnsupportedTokenParamError(response, firstParam)) {
       final alt = firstParam == 'max_tokens'
           ? 'max_completion_tokens'
           : 'max_tokens';
       response = await send(alt);
+      if (response.statusCode == 200) {
+        _learnedTokenParam = _LearnedTokenParam(
+          url.trim(),
+          _normalizedModel(effectiveModel),
+          alt,
+        );
+      }
     }
     return response;
   }
@@ -299,7 +355,8 @@ class _AiConfigPageState extends State<AiConfigPage> {
     String? tokenParamName,
   }) {
     final effectiveModel = _effectiveModel(model);
-    final key = tokenParamName ?? _tokenParamName(effectiveModel);
+    final key =
+        tokenParamName ?? _tokenParamName(_urlCtrl.text.trim(), effectiveModel);
     return <String, dynamic>{
       'model': effectiveModel,
       'messages': [
@@ -380,8 +437,9 @@ class _AiConfigPageState extends State<AiConfigPage> {
       final sampleUserContent = AppLocalizations.of(
         context,
       )!.aiTestSampleUserContent;
-      final response = await _postWithTokenFallback(url, key, model,
-          (tokenParam) {
+      final response = await _postWithTokenFallback(url, key, model, (
+        tokenParam,
+      ) {
         final requestBody = jsonEncode(
           _buildRequestPayload(
             model: model,
@@ -468,8 +526,9 @@ class _AiConfigPageState extends State<AiConfigPage> {
           ];
     final effectiveModel = _effectiveModel(model);
 
-    final response = await _postWithTokenFallback(url, key, model,
-        (tokenParam) {
+    final response = await _postWithTokenFallback(url, key, model, (
+      tokenParam,
+    ) {
       final requestBody = jsonEncode(<String, dynamic>{
         'model': effectiveModel,
         'messages': messages,
@@ -1324,6 +1383,14 @@ class _TestResult {
   final String message;
   const _TestResult.ok(this.message) : success = true;
   const _TestResult.fail(this.message) : success = false;
+}
+
+class _LearnedTokenParam {
+  const _LearnedTokenParam(this.url, this.model, this.name);
+
+  final String url;
+  final String model;
+  final String name;
 }
 
 class _TestResultCard extends StatelessWidget {


### PR DESCRIPTION
## 问题
AI 通知总结请求的 token 上限参数名现在是写死的 `max_tokens`，但 o1/gpt-5 等 OpenAI 新模型只接受 `max_completion_tokens`，传入老参数名会 400。

## 实现
三层自适应判定：
1. **名单直判**：模型前缀命中 o1/o3/o4/gpt-5 → 直接用 `max_completion_tokens`，零额外开销
2. **400 降级**：名单未命中，但收到该参数的 400 → 切换参数名重试一次（重试绕过名单，强制用切换后的值）
3. **缓存**：降级结果存 `@Volatile` 单字段，后续请求直接调用

## 改动
- `android/app/src/main/kotlin/io/github/hyperisland/xposed/template/AINotificationIslandNotification.kt`
- `lib/pages/ai_config_page.dart`

## 影响
- 默认 `gpt-4o-mini` 及大多数第三方兼容端点（DeepSeek/通义/Kimi 等）不受影响，仍走 `max_tokens`
- 用户配置无需改动
- 无新增依赖

## 测试
本地 debug 编译对于 OpenAI、DeepSeek、Gemini、NVIDIA NIM 的 `chat_completions` 能够选择正确的参数名。