### PR TITLE
fix: update broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,11 +87,11 @@ flutter build apk --target-platform=android-arm64
 
 ## Star History
 
-<a href="https://www.star-history.com/?repos=1812z%2FHyperIsland&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#1812z/HyperIsland&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/image?repos=1812z/HyperIsland&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/image?repos=1812z/HyperIsland&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/image?repos=1812z/HyperIsland&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=1812z/HyperIsland&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=1812z/HyperIsland&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=1812z/HyperIsland&type=date&legend=top-left" />
  </picture>
 </a>
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -86,11 +86,11 @@ flutter build apk --target-platform=android-arm64
 
 ## Star History
 
-<a href="https://www.star-history.com/?repos=1812z%2FHyperIsland&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#1812z/HyperIsland&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/image?repos=1812z/HyperIsland&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/image?repos=1812z/HyperIsland&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/image?repos=1812z/HyperIsland&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=1812z/HyperIsland&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=1812z/HyperIsland&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=1812z/HyperIsland&type=date&legend=top-left" />
  </picture>
 </a>
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -85,11 +85,11 @@ flutter build apk --target-platform=android-arm64
 
 ## Star History
 
-<a href="https://www.star-history.com/?repos=1812z%2FHyperIsland&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#1812z/HyperIsland&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/image?repos=1812z/HyperIsland&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/image?repos=1812z/HyperIsland&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/image?repos=1812z/HyperIsland&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=1812z/HyperIsland&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=1812z/HyperIsland&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=1812z/HyperIsland&type=date&legend=top-left" />
  </picture>
 </a>
 

--- a/README_TR.md
+++ b/README_TR.md
@@ -88,11 +88,11 @@ flutter build apk --target-platform=android-arm64
 
 ## Star History
 
-<a href="https://www.star-history.com/?repos=1812z%2FHyperIsland&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#1812z/HyperIsland&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/image?repos=1812z/HyperIsland&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/image?repos=1812z/HyperIsland&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/image?repos=1812z/HyperIsland&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=1812z/HyperIsland&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=1812z/HyperIsland&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=1812z/HyperIsland&type=date&legend=top-left" />
  </picture>
 </a>
 


### PR DESCRIPTION
The star history chart in the README is currently broken and no longer renders because the previous service relies on GitHub stargazer API data that is no longer available. This updates the chart to a working replacement so the stargazer history displays correctly again.

Updated the chart image and link in README.md, README_EN.md, README_JA.md, and README_TR.md.